### PR TITLE
Add AGENTS guidelines for CartPole notebook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS Instructions
+
+This repository aims to build an educational Jupyter notebook that is broken into clear blocks. Each block should contain a focused segment of code accompanied by descriptive commentary so readers can follow along step-by-step.
+
+## Guidelines
+- Store notebooks at the root of the repository.
+- Start with a simple reinforcement learning example using the classic CartPole environment.
+- Organize the notebook into sequential sections: environment setup, defining the agent, training loop, and evaluation.
+- Precede each code cell with a Markdown cell explaining the intent of the upcoming code.
+- Favor readability and clarity over compactness.
+
+## Testing
+Run `pytest` before committing, even if no tests are present, to ensure the test suite executes without errors.


### PR DESCRIPTION
## Summary
- add AGENTS.md with instructions for organizing the repo's Jupyter notebook and testing expectations

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3cc23801c832788b6e0dbc101251d